### PR TITLE
Link with libm for math functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ EXAMPLE_DIR=examples
 #Compiler settings
 CC    =gcc
 CFLAGS=-I$(IDIR)
+LDFLAGS=-lm
 
 #NCOMdecoder dependencies
 _DEPS = NComRxC.h
@@ -30,7 +31,7 @@ $(IDIR)/%.o: %.c $(DEPS)
 
 #Rule for the executable
 NComToCsv: $(OBJ) $(EXAMPLE)
-	gcc -o $@ $^ $(CFLAGS)
+	gcc -o $@ $^ $(CFLAGS) $(LDFLAGS)
 
 .PHONY: clean
 


### PR DESCRIPTION
This prevents errors such as `NComRxC.c:(.text+0x15e67): undefined reference to cos`